### PR TITLE
adjust excalibur benchmark to be more accurate to it's performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "babylonjs": "^8.23.1",
-    "excalibur": "^0.30.3",
+    "excalibur": "0.31.0",
     "fpsmeter": "^0.3.1",
     "hilojs": "^2.0.2",
     "kaboom": "^2000.2.10",


### PR DESCRIPTION
This benchmark is concerned with drawing as fast as possible, not necessarily the regular game dev case

* Toggles engine.physics = false, disables the built in collision subroutines and events
* Fixes benchmark code, created new graphics for every actor instead of sharing, this is very graphics memory in-efficient. New instances need to all be uploaded to the GPU.
* Uses raw graphics instead of Actors (actors are a lot like GameObjects in other engines and come with a lot of extras not related to drawing)

See this if you really need speed in drawing
* https://github.com/excaliburjs/excalibur-bunnymark/blob/main/src/main.ts
* https://excaliburjs.com/excalibur-bunnymark/